### PR TITLE
WIP: New batching channel reader with timeout

### DIFF
--- a/Open.ChannelExtensions.Tests/BasicTests.cs
+++ b/Open.ChannelExtensions.Tests/BasicTests.cs
@@ -10,15 +10,15 @@ namespace Open.ChannelExtensions.Tests
 {
 	public static class BasicTests
 	{
-		const int testSize1 = 10000001;
-		const int testSize2 = 30000001;
+		const int TestSize1 = 10000001;
+		const int TestSize2 = 30000001;
 
 		[Theory]
-		[InlineData(testSize1)]
-		[InlineData(testSize2)]
+		[InlineData(TestSize1)]
+		[InlineData(TestSize2)]
 		public static async Task DeferredWriteRead(int testSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var result = new List<int>(testSize);
 
 			var sw = Stopwatch.StartNew();
@@ -39,11 +39,11 @@ namespace Open.ChannelExtensions.Tests
 		}
 
 		[Theory]
-		[InlineData(testSize1)]
-		[InlineData(testSize2)]
+		[InlineData(TestSize1)]
+		[InlineData(TestSize2)]
 		public static async Task ReadAll(int testSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var result = new List<int>(testSize);
 
 			var sw = Stopwatch.StartNew();
@@ -61,11 +61,11 @@ namespace Open.ChannelExtensions.Tests
 		}
 
 		[Theory]
-		[InlineData(testSize1)]
-		[InlineData(testSize2)]
+		[InlineData(TestSize1)]
+		[InlineData(TestSize2)]
 		public static async Task ReadAllAsync(int testSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var result = new List<int>(testSize);
 
 			var sw = Stopwatch.StartNew();
@@ -87,11 +87,11 @@ namespace Open.ChannelExtensions.Tests
 		}
 
 		[Theory]
-		[InlineData(testSize1)]
-		[InlineData(testSize2)]
+		[InlineData(TestSize1)]
+		[InlineData(TestSize2)]
 		public static async Task PipeToBounded(int testSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var result = new List<int>(testSize);
 
 			var channel = Channel.CreateBounded<int>(new BoundedChannelOptions(100)
@@ -121,11 +121,11 @@ namespace Open.ChannelExtensions.Tests
 		}
 
 		[Theory]
-		[InlineData(testSize1)]
-		[InlineData(testSize2)]
+		[InlineData(TestSize1)]
+		[InlineData(TestSize2)]
 		public static async Task PipeToUnbound(int testSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var result = new List<int>(testSize);
 
 			var channel = Channel.CreateUnbounded<int>(new UnboundedChannelOptions()
@@ -162,7 +162,7 @@ namespace Open.ChannelExtensions.Tests
 		[InlineData(75, 50)]
 		public static async Task Batch(int testSize, int batchSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var expectedBatchCount = (testSize / batchSize) + (testSize % batchSize == 0 ? 0 : 1);
 			var result1 = new List<List<int>>(expectedBatchCount);
 
@@ -179,14 +179,14 @@ namespace Open.ChannelExtensions.Tests
 		}
 
 		[Theory]
-		[InlineData(testSize1, 51)]
-		[InlineData(testSize1, 5001)]
-		[InlineData(testSize2, 51)]
-		[InlineData(testSize2, 5001)]
+		[InlineData(TestSize1, 51)]
+		[InlineData(TestSize1, 5001)]
+		[InlineData(TestSize2, 51)]
+		[InlineData(TestSize2, 5001)]
 		[InlineData(100, 100)]
 		public static async Task BatchThenJoin(int testSize, int batchSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var result1 = new List<List<int>>(testSize / batchSize + 1);
 
 			{
@@ -244,13 +244,13 @@ namespace Open.ChannelExtensions.Tests
 		}
 
 		[Theory]
-		[InlineData(testSize1, 51)]
-		[InlineData(testSize1, 5001)]
-		[InlineData(testSize2, 51)]
-		[InlineData(testSize2, 5001)]
+		[InlineData(TestSize1, 51)]
+		[InlineData(TestSize1, 5001)]
+		[InlineData(TestSize2, 51)]
+		[InlineData(TestSize2, 5001)]
 		public static async Task BatchJoin(int testSize, int batchSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var result = new List<int>(testSize);
 
 			var sw = Stopwatch.StartNew();
@@ -303,11 +303,11 @@ namespace Open.ChannelExtensions.Tests
 		}
 
 		[Theory]
-		[InlineData(testSize1)]
-		[InlineData(testSize2)]
+		[InlineData(TestSize1)]
+		[InlineData(TestSize2)]
 		public static async Task Filter(int testSize)
 		{
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			var count = testSize / 2;
 			var result = new List<int>(count);
 

--- a/Open.ChannelExtensions.Tests/BatchTests.cs
+++ b/Open.ChannelExtensions.Tests/BatchTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;

--- a/Open.ChannelExtensions.Tests/CancellationTests.cs
+++ b/Open.ChannelExtensions.Tests/CancellationTests.cs
@@ -44,7 +44,7 @@ namespace Open.ChannelExtensions.Tests
 			const int testSize = 1000000;
 			int total = 0;
 			int count = 0;
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			using var tokenSource = new CancellationTokenSource();
 			var token = tokenSource.Token;
 			try
@@ -78,7 +78,7 @@ namespace Open.ChannelExtensions.Tests
 			const int testSize = 1000000;
 			int total = 0;
 			int count = 0;
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			using var tokenSource = new CancellationTokenSource();
 			var token = tokenSource.Token;
 			try

--- a/Open.ChannelExtensions.Tests/ExceptionTests.cs
+++ b/Open.ChannelExtensions.Tests/ExceptionTests.cs
@@ -43,7 +43,7 @@ namespace Open.ChannelExtensions.Tests
 			const int testSize = 100000000;
 			int total = 0;
 			int count = 0;
-			var range = Enumerable.Range(0, testSize);
+			var range = Enumerable.Range(0, testSize).ToList();
 			await Assert.ThrowsAsync<AggregateException>(async () =>
 			{
 				try

--- a/Open.ChannelExtensions.Tests/TimedBatchTests.cs
+++ b/Open.ChannelExtensions.Tests/TimedBatchTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Open.ChannelExtensions.Tests
+{
+	public static class TimedBatchTests
+	{
+		[Fact]
+		public static async Task SimpleBatch2Test()
+		{
+			var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+			_ = Task.Run(async () =>
+			{
+				await Task.Delay(1000);
+				c.Writer.TryWrite(1);
+				c.Writer.TryWrite(2);
+				c.Writer.TryWrite(3);
+				c.Writer.TryWrite(4);
+				c.Writer.TryWrite(5);
+				c.Writer.TryWrite(6);
+				c.Writer.Complete();
+			});
+
+			await c.Reader
+				.Batch(2, TimeSpan.FromMilliseconds(100))
+				.ReadAllAsync(async (batch, i) =>
+				{
+					switch (i)
+					{
+						case 0:
+							Assert.Equal(1, batch[0]);
+							Assert.Equal(2, batch[1]);
+							break;
+						case 1:
+							Assert.Equal(3, batch[0]);
+							Assert.Equal(4, batch[1]);
+							break;
+						case 2:
+							Assert.Equal(5, batch[0]);
+							Assert.Equal(6, batch[1]);
+							break;
+						default:
+							throw new Exception("Shouldn't arrive here.");
+					}
+					await Task.Delay(500);
+				});
+
+		}
+
+		[Fact]
+		public static async Task Batch2TestWithDelay()
+		{
+			var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+			_ = Task.Run(async () =>
+			{
+				await Task.Delay(1000);
+				c.Writer.TryWrite(1);
+				c.Writer.TryWrite(2);
+				c.Writer.TryWrite(3);
+				c.Writer.TryWrite(4);
+				c.Writer.TryWrite(5);
+				c.Writer.TryWrite(6);
+			});
+
+			using var tokenSource = new CancellationTokenSource();
+			var token = tokenSource.Token;
+			await c.Reader
+				.Batch(2,TimeSpan.FromMilliseconds(100))
+				.ReadAllAsync(async (batch, i) =>
+				{
+					switch (i)
+					{
+						case 0:
+							Assert.Equal(1, batch[0]);
+							Assert.Equal(2, batch[1]);
+							break;
+						case 1:
+							Assert.Equal(3, batch[0]);
+							Assert.Equal(4, batch[1]);
+							_ = Task.Run(async () =>
+							{
+								await Task.Delay(60000, token);
+								if (!token.IsCancellationRequested) c.Writer.TryComplete(new Exception("Should have completed successfuly."));
+							});
+							break;
+						case 2:
+							Assert.Equal(5, batch[0]);
+							Assert.Equal(6, batch[1]);
+							tokenSource.Cancel();
+							c.Writer.Complete();
+							break;
+						default:
+							throw new Exception("Shouldn't arrive here.");
+					}
+					await Task.Delay(500);
+				});
+
+		}
+    }
+}

--- a/Open.ChannelExtensions/Extensions.Batch.cs
+++ b/Open.ChannelExtensions/Extensions.Batch.cs
@@ -7,9 +7,7 @@ namespace Open.ChannelExtensions
 {
 	public static partial class Extensions
 	{
-		
-
-		/// <summary>
+        /// <summary>
 		/// Batches results into the batch size provided with a max capacity of batches.
 		/// </summary>
 		/// <typeparam name="T">The output type of the source channel.</typeparam>
@@ -20,5 +18,19 @@ namespace Open.ChannelExtensions
 		/// <returns>A channel reader containing the batches.</returns>
 		public static BatchingChannelReader<T> Batch<T>(this ChannelReader<T> source, int batchSize, bool singleReader = false, bool allowSynchronousContinuations = false)
 			=> new BatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, singleReader, allowSynchronousContinuations);
+
+        /// <summary>
+        /// Batches results into the batch size provided with a max capacity of batches.
+        /// Flushes incomplete batches automatically after the provided timeout.
+        /// </summary>
+        /// <typeparam name="T">The output type of the source channel.</typeparam>
+        /// <param name="source">The channel to read from.</param>
+        /// <param name="batchSize">The maximum size of each batch.</param>
+        /// <param name="batchTimeout">The maximum wait time until another item is written.</param>
+        /// <param name="singleReader">True will cause the resultant reader to optimize for the assumption that no concurrent read operations will occur.</param>
+        /// <param name="allowSynchronousContinuations">True can reduce the amount of scheduling and markedly improve performance, but may produce unexpected or even undesirable behavior.</param>
+        /// <returns>A channel reader containing the batches.</returns>
+        public static TimedBatchingChannelReader<T> Batch<T>(this ChannelReader<T> source, int batchSize, TimeSpan batchTimeout, bool singleReader = false, bool allowSynchronousContinuations = false)
+            => new TimedBatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, batchTimeout, singleReader, allowSynchronousContinuations);
 	}
 }

--- a/Open.ChannelExtensions/Extensions._.cs
+++ b/Open.ChannelExtensions/Extensions._.cs
@@ -415,6 +415,5 @@ namespace Open.ChannelExtensions
 			CancellationToken cancellationToken = default)
 			=> CreateChannel<T>(capacity, singleReader)
 				.SourceAsync(maxConcurrency, source, cancellationToken);
-
-	}
+    }
 }

--- a/Open.ChannelExtensions/TimedBatchingChannelReader.cs
+++ b/Open.ChannelExtensions/TimedBatchingChannelReader.cs
@@ -1,0 +1,170 @@
+namespace Open.ChannelExtensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Threading;
+    using System.Threading.Channels;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A ChannelReader that batches results.
+    /// Use the .Batch extension instead of constructing this directly.
+    /// </summary>
+    public class TimedBatchingChannelReader<T> : BufferingChannelReader<T, List<T>>
+    {
+        readonly int      _batchSize;
+        readonly TimeSpan _batchTimeout;
+
+        List<T>? _batch;
+
+        /// <summary>
+        /// Constructs a BatchingChannelReader.
+        /// Use the .Batch extension instead of constructing this directly.
+        /// </summary>
+        public TimedBatchingChannelReader(ChannelReader<T> source, int batchSize, TimeSpan batchTimeout, bool singleReader, bool syncCont = false) : base(
+            source, singleReader, syncCont
+        ) {
+            if (batchSize < 1) throw new ArgumentOutOfRangeException(nameof(batchSize), batchSize, "Must be at least 1.");
+
+            Contract.EndContractBlock();
+
+            _batchSize    = batchSize;
+            _batchTimeout = batchTimeout;
+        }
+
+        /// <inheritdoc />
+        protected override bool TryPipeItems() {
+            if (Buffer?.Reader.Completion.IsCompleted != false)
+                return false;
+
+            lock (Buffer) {
+                if (Buffer.Reader.Completion.IsCompleted) return false;
+
+                var c      = _batch;
+                var source = Source;
+
+                if (source?.Completion.IsCompleted != false) {
+                    // All finished, release the last batch to the buffer.
+                    if (c == null) return false;
+
+                    c.TrimExcess();
+                    _batch = null;
+                    Buffer.Writer.TryWrite(c);
+                    return true;
+                }
+
+                while (source.TryRead(out var item)) {
+                    if (c == null) _batch = c = new List<T>(_batchSize) { item };
+                    else c.Add(item);
+
+                    if (c.Count == _batchSize) {
+                        _batch = null;
+                        Buffer.Writer.TryWrite(c);
+                        return true;
+                    }
+                }
+
+                return false;
+
+                //
+                // while (true) {
+                //     var empty = !source.TryRead(out var item);
+                //
+                //     if (empty) {
+                //         // wait for another item before timing out and releasing the last batch to the buffer.
+                //         Task.Delay(_batchTimeout).GetAwaiter().GetResult();
+                //
+                //         var stillEmpty = !source.TryRead(out item);
+                //
+                //         // there is not hope so flush
+                //         if (stillEmpty) {
+                //             if (c?.Count > 0) {
+                //                 c.TrimExcess();
+                //                 _batch = null;
+                //                 Buffer.Writer.TryWrite(c);
+                //                 return true;
+                //             }
+                //
+                //             return false;
+                //         }
+                //     }
+                //
+                //     if (c == null) _batch = c = new List<T>(_batchSize) { item };
+                //     else c.Add(item);
+                //
+                //     if (c.Count == _batchSize) {
+                //         _batch = null;
+                //         Buffer.Writer.TryWrite(c);
+                //         return true;
+                //     }
+                // }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override async ValueTask<bool> WaitToReadAsyncCore(ValueTask<bool> bufferWait, CancellationToken cancellationToken) {
+            var source = Source;
+
+            if (source == null)
+                return await bufferWait.ConfigureAwait(false);
+
+            var b = bufferWait.AsTask();
+
+            using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            var token = tokenSource.Token;
+
+            start:
+
+            if (b.IsCompleted) return await b.ConfigureAwait(false);
+
+            var s = source.WaitToReadAsync(token);
+
+            if (s.IsCompleted && !b.IsCompleted)
+                await TryPipeItemsWithTimeout(cancellationToken).ConfigureAwait(false);
+
+            if (b.IsCompleted) {
+                tokenSource.Cancel();
+                return await b.ConfigureAwait(false);
+            }
+
+            await Task.WhenAny(s.AsTask(), b).ConfigureAwait(false);
+
+            if (b.IsCompleted) {
+                tokenSource.Cancel();
+                return await b.ConfigureAwait(false);
+            }
+
+            await TryPipeItemsWithTimeout(cancellationToken).ConfigureAwait(false);
+            goto start;
+        }
+
+        async ValueTask<bool> TryPipeItemsWithTimeout(CancellationToken cancellationToken) {
+            if (TryPipeItems()) return true;
+
+            await Task.Delay(_batchTimeout, cancellationToken).ConfigureAwait(false);
+
+            if (TryPipeItems()) return true; // still empty
+
+            if (Buffer?.Reader.Completion.IsCompleted != false)
+                return false;
+
+            lock (Buffer) {
+                if (Buffer.Reader.Completion.IsCompleted)
+                    return false;
+
+                var c = _batch;
+
+                if (c?.Count > 0) {
+                    c.TrimExcess();
+                    _batch = null;
+                    Buffer.Writer.TryWrite(c);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Hi, thanks for the great lib.

This PR essentially adds the capability to automatically flush and incomplete buffer, once a certain time span has passed since the last message was buffered.

The only pluggable points were  `TryPipeItems` and `WaitToReadAsyncCore`.

I first used `TryPipeItems` as it seemed logical, but needed to away the delay. So ended up going for the `WaitToReadAsyncCore` that was already `async`.

Cheers,
