### PR TITLE
README - comment for Join example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ values.Reader
 
 ```cs
 batches.Reader
-    .Join()
+    .Join() // .SelectMany()
     .ReadAllAsync(async value => {/*...*/});
 ```
 


### PR DESCRIPTION
I found "Join" to be a tad confusing for something that basically unbundles collections. Your other references to Linq equivalents are helpful, so I thought this might be helpful here. Thanks!