### PR TITLE
Add batching with IMemoryOwner<T> and related tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -93,7 +93,7 @@ csharp_style_pattern_matching_over_as_with_null_check = true:warning
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_prefer_not_pattern = true:warning
 csharp_style_prefer_pattern_matching = true:suggestion
-csharp_style_prefer_switch_expression = true
+csharp_style_prefer_switch_expression = true:suggestion
 
 # Null-checking preferences
 csharp_style_conditional_delegate_call = true:warning
@@ -143,7 +143,7 @@ csharp_new_line_between_query_expression_clauses = true
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
+csharp_indent_case_contents_when_block = false
 csharp_indent_labels = one_less_than_current
 csharp_indent_switch_labels = true
 

--- a/Open.ChannelExtensions.Benchmarks/BatchDrain.cs
+++ b/Open.ChannelExtensions.Benchmarks/BatchDrain.cs
@@ -1,0 +1,113 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Threading.Channels;
+
+namespace Open.ChannelExtensions.Benchmarks;
+
+[MemoryDiagnoser]
+public class BatchDrain
+{
+	[Params(10, 100, 500, 1000, 3000, 12000)]
+	public int BatchSize { get; set; }
+
+	public int TotalItems = 10000000;
+
+	private Channel<int>? _channel;
+
+	private readonly Queue<List<int>> _listPool = new();
+	private readonly Queue<Queue<int>> _queuePool = new();
+
+	private int _noOpTarget;
+
+	private int NoOp(int value) => _noOpTarget = value;
+
+	[GlobalCleanup]
+	public void GlobalCleanup()
+	{
+		// Ensure the compiler doesn't optimize away the target.
+		Console.WriteLine("NoOp Target: {0}", _noOpTarget);
+	}
+
+	[IterationSetup]
+	public void IterationSetup()
+	{
+		_channel = Channel.CreateUnbounded<int>(new UnboundedChannelOptions
+		{
+			SingleReader = true,
+			SingleWriter = true
+		});
+
+		for (int i = 0; i < TotalItems; i++)
+		{
+			_channel.Writer.TryWrite(i);
+		}
+
+		_channel.Writer.Complete();
+
+		_listPool.Clear();
+		_queuePool.Clear();
+
+		_listPool.Enqueue(new List<int>(BatchSize));
+		_listPool.Enqueue(new List<int>(BatchSize));
+		_queuePool.Enqueue(new Queue<int>(BatchSize));
+		_queuePool.Enqueue(new Queue<int>(BatchSize));
+	}
+
+	[Benchmark(Baseline = true)]
+	public async Task BatchListDrain()
+		=> await _channel!.Reader
+			.Batch(BatchSize)
+			.ReadAll(e =>
+			{
+				for (var i = 0; i < e.Count; i++)
+					_noOpTarget -= NoOp(e[i]);
+			});
+
+	[Benchmark]
+	public async Task BatchListDrainPooled()
+	=> await _channel!.Reader
+		.Batch(BatchSize, batchFactory: _ => _listPool.Dequeue())
+		.ReadAll(e =>
+		{
+			for(var i = 0; i < e.Count; i++)
+				_noOpTarget -= NoOp(e[i]);
+
+			e.Clear(); // Simulate resetting the size.
+			_listPool.Enqueue(e);
+		});
+
+	[Benchmark]
+	public async Task BatchQueueDrain()
+		=> await _channel!.Reader
+			.BatchToQueues(BatchSize)
+			.ReadAll(e =>
+			{
+				while (e.TryDequeue(out var value))
+					_noOpTarget -= NoOp(value);
+			});
+
+	[Benchmark]
+	public async Task BatchQueueDrainPooled()
+		=> await _channel!.Reader
+			.BatchToQueues(BatchSize, batchFactory: _ => _queuePool.Dequeue())
+			.ReadAll(e =>
+			{
+				while(e.TryDequeue(out var value))
+					_noOpTarget -= NoOp(value);
+
+				_queuePool.Enqueue(e);
+			});
+
+	[Benchmark]
+	public async Task BatchMemoryOwnerDrain()
+		=> await _channel!.Reader
+			.BatchAsMemory(BatchSize)
+			.ReadAll(e =>
+			{
+				var span = e.Memory.Span;
+				var len = span.Length;
+				for (var i = 0; i < len; i++)
+					_noOpTarget -= NoOp(span[i]);
+
+				e.Dispose();
+			});
+}

--- a/Open.ChannelExtensions.Benchmarks/Open.ChannelExtensions.Benchmarks.csproj
+++ b/Open.ChannelExtensions.Benchmarks/Open.ChannelExtensions.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Open.ChannelExtensions\Open.ChannelExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Open.ChannelExtensions.Benchmarks/Program.cs
+++ b/Open.ChannelExtensions.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+﻿using Open.ChannelExtensions.Benchmarks;
+using BenchmarkDotNet.Running;
+BenchmarkRunner.Run<BatchDrain>();

--- a/Open.ChannelExtensions.Tests/BatchTests.Memory.cs
+++ b/Open.ChannelExtensions.Tests/BatchTests.Memory.cs
@@ -1,0 +1,432 @@
+﻿using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Open.ChannelExtensions.Tests;
+
+public static class BatchTestsOfMemoryOwner
+{
+	[Fact]
+	public static async Task SimpleBatch2Test()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			c.Writer.TryWrite(6);
+			c.Writer.Complete();
+		});
+
+		await c.Reader
+			.BatchAsMemory(2)
+			.ReadAllAsync(async (owner, i) =>
+			{
+				using var _ = owner;
+				var batch = owner.Memory;
+				switch (i)
+				{
+					case 0:
+						Assert.Equal(1, batch.Span[0]);
+						Assert.Equal(2, batch.Span[1]);
+						break;
+
+					case 1:
+						Assert.Equal(3, batch.Span[0]);
+						Assert.Equal(4, batch.Span[1]);
+						break;
+
+					case 2:
+						Assert.Equal(5, batch.Span[0]);
+						Assert.Equal(6, batch.Span[1]);
+						break;
+
+					default:
+						throw new Exception("Shouldn't arrive here.");
+				}
+				await Task.Delay(500);
+			});
+	}
+
+	[Fact]
+	public static async Task Batch2TestWithDelay()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			c.Writer.TryWrite(6);
+		});
+
+		using var tokenSource = new CancellationTokenSource();
+		CancellationToken token = tokenSource.Token;
+		await c.Reader
+			.BatchAsMemory(2)
+			.ReadAllAsync(async (owner, i) =>
+			{
+				using var __ = owner;
+				var batch = owner.Memory;
+
+				switch (i)
+				{
+					case 0:
+						Assert.Equal(1, batch.Span[0]);
+						Assert.Equal(2, batch.Span[1]);
+						break;
+					case 1:
+						Assert.Equal(3, batch.Span[0]);
+						Assert.Equal(4, batch.Span[1]);
+						_ = Task.Run(async () =>
+						{
+							await Task.Delay(60000, token);
+							if (!token.IsCancellationRequested) c.Writer.TryComplete(new Exception("Should have completed successfully."));
+						});
+						break;
+					case 2:
+						Assert.Equal(5, batch.Span[0]);
+						Assert.Equal(6, batch.Span[1]);
+						tokenSource.Cancel();
+						c.Writer.Complete();
+						break;
+					default:
+						throw new Exception("Shouldn't arrive here.");
+				}
+				await Task.Delay(500);
+			});
+	}
+
+	[Fact]
+	public static async Task ForceBatchTest()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+		});
+
+		using var tokenSource = new CancellationTokenSource(10000);
+		var reader = c.Reader.BatchAsMemory(3);
+		Assert.Equal(2, await reader.ReadAllAsync(tokenSource.Token, async (owner, i) =>
+		{
+			using var _ = owner;
+			var batch = owner.Memory;
+
+			switch (i)
+			{
+				case 0:
+					Assert.Equal(1, batch.Span[0]);
+					Assert.Equal(2, batch.Span[1]);
+					Assert.Equal(3, batch.Span[2]);
+					await Task.Delay(500);
+					reader.ForceBatch();
+					break;
+				case 1:
+					Assert.Equal(2, batch.Length);
+					Assert.Equal(4, batch.Span[0]);
+					Assert.Equal(5, batch.Span[1]);
+					c.Writer.Complete();
+					break;
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(500);
+		}));
+	}
+
+	[Fact]
+	public static async Task ForceBatchTest2()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchAsMemory(3);
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			Debug.WriteLine("Writing Complete.");
+
+			await Task.Delay(1000);
+			Assert.True(reader.ForceBatch());
+			Debug.WriteLine("Batch Forced.");
+		});
+
+		using var tokenSource = new CancellationTokenSource(6000);
+		Assert.Equal(2, await reader.ReadAllAsync(tokenSource.Token, async (owner, i) =>
+		{
+			using var _ = owner;
+			var batch = owner.Memory;
+
+			switch (i)
+			{
+				case 0:
+					Assert.Equal(1, batch.Span[0]);
+					Assert.Equal(2, batch.Span[1]);
+					Assert.Equal(3, batch.Span[2]);
+					Debug.WriteLine("First batch received.");
+					break;
+				case 1:
+					Assert.Equal(2, batch.Length);
+					Assert.Equal(4, batch.Span[0]);
+					Assert.Equal(5, batch.Span[1]);
+					Debug.WriteLine("Second batch received.");
+					c.Writer.Complete();
+					break;
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(500);
+		}));
+	}
+
+	[Fact]
+	public static async Task TimeoutTest0()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchAsMemory(10).WithTimeout(500);
+		var complete = false;
+		_ = Task.Run(async () =>
+		{
+			for (var i = 0; i < 5; i++)
+			{
+				c.Writer.TryWrite(i);
+			}
+
+			await Task.Delay(1000);
+			complete = true;
+			c.Writer.Complete();
+		});
+
+		using var tokenSource = new CancellationTokenSource(6000);
+		Assert.Equal(1, await reader.ReadAllAsync(tokenSource.Token, async (owner, i) =>
+		{
+			using var _ = owner;
+			var batch = owner.Memory;
+			switch (i)
+			{
+				case 0:
+					Assert.Equal(5, batch.Length);
+					Assert.False(complete);
+					break;
+
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(100);
+		}));
+	}
+
+	[Fact]
+	public static async Task TimeoutTest1()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchAsMemory(10).WithTimeout(500);
+		_ = Task.Run(async () =>
+		{
+			for (var i = 0; i < 15; i++)
+			{
+				c.Writer.TryWrite(i);
+			}
+
+			await Task.Delay(1000);
+
+			for (var i = 0; i < 15; i++)
+			{
+				c.Writer.TryWrite(i);
+			}
+			c.Writer.Complete();
+		});
+
+		using var tokenSource = new CancellationTokenSource(6000);
+		Assert.Equal(4, await reader.ReadAllAsync(tokenSource.Token, async (owner, i) =>
+		{
+			using var _ = owner;
+			var batch = owner.Memory;
+
+			switch (i)
+			{
+				case 0:
+				case 2:
+					Assert.Equal(10, batch.Length);
+					break;
+				case 1:
+				case 3:
+					Assert.Equal(5, batch.Length);
+					break;
+
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(100);
+		}));
+	}
+
+	[Fact]
+	public static async Task BatchReadBehavior()
+	{
+		var c = Channel.CreateBounded<int>(new BoundedChannelOptions(20) { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchAsMemory(10);
+
+		var queue = new Queue<int>(Enumerable.Range(0, 100));
+		int e;
+		while (queue.TryDequeue(out e) && c.Writer.TryWrite(e))
+			await Task.Yield();
+
+		IMemoryOwner<int> batch = null;
+		Assert.True(69 <= queue.Count);
+		await reader.WaitToReadAsync();
+		// At this point, a batch is prepared and there is room in the channel.
+		await Dequeue();
+
+		Assert.True(59 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		// At this point nothing is waiting so either a wait must occur or a read to trigger a new batch.
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		await Dequeue();
+
+		Assert.True(49 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		await Dequeue();
+
+		Assert.True(39 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		await Dequeue();
+
+		Assert.True(29 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		await Dequeue();
+
+		Assert.True(19 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		await Dequeue();
+
+		Assert.True(09 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		await Dequeue();
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		await Dequeue();
+
+		Assert.Empty(queue);
+		c.Writer.Complete();
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		batch.Dispose();
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Memory.Length);
+		batch?.Dispose();
+
+		Assert.False(reader.TryRead(out batch));
+		batch?.Dispose();
+
+		async ValueTask Dequeue()
+		{
+			batch?.Dispose();
+			if (!c.Writer.TryWrite(e)) return;
+			while (queue.TryDequeue(out e) && c.Writer.TryWrite(e))
+				await Task.Yield();
+		}
+	}
+
+	[Fact]
+	public static async Task ReadBatchWithTimeoutEnumerableBakedIn()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			//await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+
+			c.Writer.TryWrite(3);
+			await Task.Delay(600);
+
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			Debug.WriteLine("Writing Complete.");
+			c.Writer.Complete();
+		});
+		var i = 0;
+		await foreach (var owner in c.Reader.ReadBatchMemoryEnumerableAsyncBakedIn(2, TimeSpan.FromMilliseconds(500), CancellationToken.None))
+		{
+			using var _ = owner;
+			var batch = owner.Memory;
+
+			switch (i)
+			{
+				case 0:
+					Assert.Equal(1, batch.Span[0]);
+					Assert.Equal(2, batch.Span[1]);
+					break;
+				case 1:
+					Assert.Equal(1, batch.Length);
+					Assert.Equal(3, batch.Span[0]);
+					break;
+				case 2:
+					Assert.Equal(4, batch.Span[0]);
+					Assert.Equal(5, batch.Span[1]);
+					break;
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			i++;
+		}
+		Assert.Equal(3, i);
+		await c.Reader.Completion; // Propagate possible failure
+	}
+
+	public static async IAsyncEnumerable<IMemoryOwner<T>> ReadBatchMemoryEnumerableAsyncBakedIn<T>(
+		this ChannelReader<T> channelReader,
+		int batchSize,
+		TimeSpan timeout,
+		[EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		var reader = channelReader.BatchAsMemory(batchSize);
+		reader = reader.WithTimeout(timeout); // stack overflow here
+		while (true)
+		{
+			IMemoryOwner<T> item;
+			try
+			{
+				item = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				yield break;
+			}
+			catch (ChannelClosedException)
+			{
+				yield break;
+			}
+
+			if (item?.Memory.Length > 0) yield return item;
+		}
+	}
+}

--- a/Open.ChannelExtensions.Tests/BatchTests.Queue.cs
+++ b/Open.ChannelExtensions.Tests/BatchTests.Queue.cs
@@ -181,7 +181,6 @@ public static class BatchTestsOfQueue
 		using var tokenSource = new CancellationTokenSource(6000);
 		Assert.Equal(2, await reader.ReadAllAsync(tokenSource.Token, async (batch, i) =>
 		{
-
 			switch (i)
 			{
 				case 0:
@@ -386,8 +385,6 @@ public static class BatchTestsOfQueue
 		var i = 0;
 		await foreach (var batch in c.Reader.ReadBatchQueueEnumerableAsyncBakedIn(2, TimeSpan.FromMilliseconds(500), CancellationToken.None))
 		{
-
-
 			switch (i)
 			{
 				case 0:

--- a/Open.ChannelExtensions.Tests/BatchTests.Queue.cs
+++ b/Open.ChannelExtensions.Tests/BatchTests.Queue.cs
@@ -1,0 +1,452 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Open.ChannelExtensions.Tests;
+
+public static class BatchTestsOfQueue
+{
+	[Fact]
+	public static async Task SimpleBatch2Test()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			c.Writer.TryWrite(6);
+			c.Writer.Complete();
+		});
+
+		await c.Reader
+			.BatchToQueues(2)
+			.ReadAllAsync(async (batch, i) =>
+			{
+				var a = batch.Dequeue();
+				var b = batch.Dequeue();
+				switch (i)
+				{
+					case 0:
+						Assert.Equal(1, a);
+						Assert.Equal(2, b);
+						break;
+
+					case 1:
+						Assert.Equal(3, a);
+						Assert.Equal(4, b);
+						break;
+
+					case 2:
+						Assert.Equal(5, a);
+						Assert.Equal(6, b);
+						break;
+
+					default:
+						throw new Exception("Shouldn't arrive here.");
+				}
+				await Task.Delay(500);
+			});
+	}
+
+	[Fact]
+	public static async Task Batch2TestWithDelay()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			c.Writer.TryWrite(6);
+		});
+
+		using var tokenSource = new CancellationTokenSource();
+		CancellationToken token = tokenSource.Token;
+		await c.Reader
+			.BatchToQueues(2)
+			.ReadAllAsync(async (batch, i) =>
+			{
+				var a = batch.Dequeue();
+				var b = batch.Dequeue();
+
+				switch (i)
+				{
+					case 0:
+						Assert.Equal(1, a);
+						Assert.Equal(2, b);
+						break;
+					case 1:
+						Assert.Equal(3, a);
+						Assert.Equal(4, b);
+						_ = Task.Run(async () =>
+						{
+							await Task.Delay(60000, token);
+							if (!token.IsCancellationRequested) c.Writer.TryComplete(new Exception("Should have completed successfully."));
+						});
+						break;
+					case 2:
+						Assert.Equal(5, a);
+						Assert.Equal(6, b);
+						tokenSource.Cancel();
+						c.Writer.Complete();
+						break;
+					default:
+						throw new Exception("Shouldn't arrive here.");
+				}
+				await Task.Delay(500);
+			});
+	}
+
+	[Fact]
+	public static async Task ForceBatchTest()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+		});
+
+		using var tokenSource = new CancellationTokenSource(10000);
+		var reader = c.Reader.BatchToQueues(3);
+		Assert.Equal(2, await reader.ReadAllAsync(tokenSource.Token, async (batch, i) =>
+		{
+			switch (i)
+			{
+				case 0:
+				{
+					Assert.Equal(3, batch.Count);
+
+					var e1 = batch.Dequeue();
+					var e2 = batch.Dequeue();
+					var e3 = batch.Dequeue();
+
+					Assert.Equal(1, e1);
+					Assert.Equal(2, e2);
+					Assert.Equal(3, e3);
+					await Task.Delay(500);
+					reader.ForceBatch();
+					break;
+				}
+
+				case 1:
+				{
+					Assert.Equal(2, batch.Count);
+
+					var e1 = batch.Dequeue();
+					var e2 = batch.Dequeue();
+
+					Assert.Equal(4, e1);
+					Assert.Equal(5, e2);
+					c.Writer.Complete();
+					break;
+				}
+
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(500);
+		}));
+	}
+
+	[Fact]
+	public static async Task ForceBatchTest2()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchToQueues(3);
+		_ = Task.Run(async () =>
+		{
+			await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+			c.Writer.TryWrite(3);
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			Debug.WriteLine("Writing Complete.");
+
+			await Task.Delay(1000);
+			Assert.True(reader.ForceBatch());
+			Debug.WriteLine("Batch Forced.");
+		});
+
+		using var tokenSource = new CancellationTokenSource(6000);
+		Assert.Equal(2, await reader.ReadAllAsync(tokenSource.Token, async (batch, i) =>
+		{
+
+			switch (i)
+			{
+				case 0:
+				{
+					Assert.Equal(3, batch.Count);
+					var e1 = batch.Dequeue();
+					var e2 = batch.Dequeue();
+					var e3 = batch.Dequeue();
+					Assert.Equal(1, e1);
+					Assert.Equal(2, e2);
+					Assert.Equal(3, e3);
+					Debug.WriteLine("First batch received.");
+					break;
+				}
+
+				case 1:
+				{
+					Assert.Equal(2, batch.Count);
+					var e1 = batch.Dequeue();
+					var e2 = batch.Dequeue();
+					Assert.Equal(4, e1);
+					Assert.Equal(5, e2);
+					Debug.WriteLine("Second batch received.");
+					c.Writer.Complete();
+					break;
+				}
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(500);
+		}));
+	}
+
+	[Fact]
+	public static async Task TimeoutTest0()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchToQueues(10).WithTimeout(500);
+		var complete = false;
+		_ = Task.Run(async () =>
+		{
+			for (var i = 0; i < 5; i++)
+			{
+				c.Writer.TryWrite(i);
+			}
+
+			await Task.Delay(1000);
+			complete = true;
+			c.Writer.Complete();
+		});
+
+		using var tokenSource = new CancellationTokenSource(6000);
+		Assert.Equal(1, await reader.ReadAllAsync(tokenSource.Token, async (batch, i) =>
+		{
+			switch (i)
+			{
+				case 0:
+					Assert.Equal(5, batch.Count);
+					Assert.False(complete);
+					break;
+
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(100);
+		}));
+	}
+
+	[Fact]
+	public static async Task TimeoutTest1()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchToQueues(10).WithTimeout(500);
+		_ = Task.Run(async () =>
+		{
+			for (var i = 0; i < 15; i++)
+			{
+				c.Writer.TryWrite(i);
+			}
+
+			await Task.Delay(1000);
+
+			for (var i = 0; i < 15; i++)
+			{
+				c.Writer.TryWrite(i);
+			}
+			c.Writer.Complete();
+		});
+
+		using var tokenSource = new CancellationTokenSource(6000);
+		Assert.Equal(4, await reader.ReadAllAsync(tokenSource.Token, async (batch, i) =>
+		{
+			switch (i)
+			{
+				case 0:
+				case 2:
+					Assert.Equal(10, batch.Count);
+					break;
+				case 1:
+				case 3:
+					Assert.Equal(5, batch.Count);
+					break;
+
+				default:
+					throw new Exception("Shouldn't arrive here.");
+			}
+			await Task.Delay(100);
+		}));
+	}
+
+	[Fact]
+	public static async Task BatchReadBehavior()
+	{
+		var c = Channel.CreateBounded<int>(new BoundedChannelOptions(20) { SingleReader = false, SingleWriter = false });
+		var reader = c.Reader.BatchToQueues(10);
+
+		var queue = new Queue<int>(Enumerable.Range(0, 100));
+		int e;
+		while (queue.TryDequeue(out e) && c.Writer.TryWrite(e))
+			await Task.Yield();
+
+		Assert.True(69 <= queue.Count);
+		await reader.WaitToReadAsync();
+		// At this point, a batch is prepared and there is room in the channel.
+		await Dequeue();
+
+		Assert.True(59 <= queue.Count);
+		Assert.True(reader.TryRead(out var batch));
+		Assert.Equal(10, batch.Count);
+		// At this point nothing is waiting so either a wait must occur or a read to trigger a new batch.
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+		await Dequeue();
+
+		Assert.True(49 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+		await Dequeue();
+
+		Assert.True(39 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+		await Dequeue();
+
+		Assert.True(29 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+		await Dequeue();
+
+		Assert.True(19 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+		await Dequeue();
+
+		Assert.True(09 <= queue.Count);
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+		await Dequeue();
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+		await Dequeue();
+
+		Assert.Empty(queue);
+		c.Writer.Complete();
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+
+		Assert.True(reader.TryRead(out batch));
+		Assert.Equal(10, batch.Count);
+
+		Assert.False(reader.TryRead(out _));
+
+		async ValueTask Dequeue()
+		{
+			if (!c.Writer.TryWrite(e)) return;
+			while (queue.TryDequeue(out e) && c.Writer.TryWrite(e))
+				await Task.Yield();
+		}
+	}
+
+	[Fact]
+	public static async Task ReadBatchWithTimeoutEnumerableBakedIn()
+	{
+		var c = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+		_ = Task.Run(async () =>
+		{
+			//await Task.Delay(1000);
+			c.Writer.TryWrite(1);
+			c.Writer.TryWrite(2);
+
+			c.Writer.TryWrite(3);
+			await Task.Delay(600);
+
+			c.Writer.TryWrite(4);
+			c.Writer.TryWrite(5);
+			Debug.WriteLine("Writing Complete.");
+			c.Writer.Complete();
+		});
+		var i = 0;
+		await foreach (var batch in c.Reader.ReadBatchQueueEnumerableAsyncBakedIn(2, TimeSpan.FromMilliseconds(500), CancellationToken.None))
+		{
+
+
+			switch (i)
+			{
+				case 0:
+				{
+					var a = batch.Dequeue();
+					var b = batch.Dequeue();
+					Assert.Equal(1, a);
+					Assert.Equal(2, b);
+					Debug.WriteLine("First batch received: " + string.Join(',', batch.Select(item => item)));
+					break;
+				}
+
+				case 1:
+					Assert.Single(batch);
+					Assert.Equal(3, batch.Dequeue());
+					Debug.WriteLine("Second batch received: " + string.Join(',', batch.Select(item => item)));
+					break;
+
+				case 2:
+					Assert.Equal(4, batch.Dequeue());
+					Assert.Equal(5, batch.Dequeue());
+					Debug.WriteLine("Third batch received: " + string.Join(',', batch.Select(item => item)));
+					break;
+
+				default:
+					throw new Exception("Shouldn't arrive here. Got batch: " + string.Join(',', batch.Select(item => item)));
+			}
+			i++;
+		}
+		Assert.Equal(3, i);
+		await c.Reader.Completion; // Propagate possible failure
+	}
+
+	public static async IAsyncEnumerable<Queue<T>> ReadBatchQueueEnumerableAsyncBakedIn<T>(
+		this ChannelReader<T> channelReader,
+		int batchSize,
+		TimeSpan timeout,
+		[EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		var reader = channelReader.BatchToQueues(batchSize);
+		reader = reader.WithTimeout(timeout); // stack overflow here
+		while (true)
+		{
+			Queue<T> item;
+			try
+			{
+				item = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				yield break;
+			}
+			catch (ChannelClosedException)
+			{
+				yield break;
+			}
+
+			if (item?.Count > 0) yield return item;
+		}
+	}
+}

--- a/Open.ChannelExtensions.Tests/SpecialTests.cs
+++ b/Open.ChannelExtensions.Tests/SpecialTests.cs
@@ -7,7 +7,7 @@ public class SpecialTests
 	[Fact]
 	public async Task PossibleSourceLoadingIssue()
 	{
-		const int expectedCount = 10000000;
+		const int expectedCount = 1000000;
 		int count_ = 0;
 
 		var queue = new BlockingCollection<int>();

--- a/Open.ChannelExtensions.sln
+++ b/Open.ChannelExtensions.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Open.ChannelExtensions.Benchmarks", "Open.ChannelExtensions.Benchmarks\Open.ChannelExtensions.Benchmarks.csproj", "{643E4B6B-2AC7-4981-A8A3-92E4B8E176B5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,6 +36,10 @@ Global
 		{F13B7605-FB04-4769-B182-77482C900B28}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F13B7605-FB04-4769-B182-77482C900B28}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F13B7605-FB04-4769-B182-77482C900B28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{643E4B6B-2AC7-4981-A8A3-92E4B8E176B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{643E4B6B-2AC7-4981-A8A3-92E4B8E176B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{643E4B6B-2AC7-4981-A8A3-92E4B8E176B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{643E4B6B-2AC7-4981-A8A3-92E4B8E176B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Open.ChannelExtensions/Extensions.Batch.cs
+++ b/Open.ChannelExtensions/Extensions.Batch.cs
@@ -1,7 +1,11 @@
-﻿namespace Open.ChannelExtensions;
+﻿using System.Buffers;
+
+namespace Open.ChannelExtensions;
 
 public static partial class Extensions
 {
+	// Note: the return types are normalized to ensure the same API surface area.
+
 	/// <summary>
 	/// Batches results into the batch size provided with a max capacity of batches.
 	/// </summary>
@@ -28,4 +32,19 @@ public static partial class Extensions
 		bool singleReader = false,
 		bool allowSynchronousContinuations = false)
 		=> new QueueBatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, singleReader, allowSynchronousContinuations);
+
+	/// <remarks>
+	/// <list type="bullet">
+	/// <item>The <see cref="Memory{T}"/> returned will always be less than or equal to the batch size.</item>
+	/// <item>It is important to manage disposing of the resultant <see cref="IMemoryOwner{T}"/> and not access them after disposal.</item>
+	/// </list>
+	/// See <see cref="MemoryPool{T}"/> for more information. It may be more benefitial to use this for larger batch sizes.
+	/// </remarks>
+	/// <inheritdoc cref="Batch{T}(ChannelReader{T}, int, bool, bool)" />
+	public static BatchingChannelReader<T, IMemoryOwner<T>> BatchAsMemory<T>(
+		this ChannelReader<T> source,
+		int batchSize,
+		bool singleReader = false,
+		bool allowSynchronousContinuations = false)
+		=> new MemoryPooledBatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, singleReader, allowSynchronousContinuations);
 }

--- a/Open.ChannelExtensions/Extensions.Batch.cs
+++ b/Open.ChannelExtensions/Extensions.Batch.cs
@@ -17,30 +17,35 @@ public static partial class Extensions
 	/// </param>
 	/// <param name="singleReader">True will cause the resultant reader to optimize for the assumption that no concurrent read operations will occur.</param>
 	/// <param name="allowSynchronousContinuations">True can reduce the amount of scheduling and markedly improve performance, but may produce unexpected or even undesirable behavior.</param>
+	/// <param name="batchFactory">The optional factory delegate to get or create new batches.</param>
 	/// <returns>A channel reader containing the batches.</returns>
 	public static BatchingChannelReader<T, List<T>> Batch<T>(
 		this ChannelReader<T> source,
 		int batchSize,
 		bool singleReader = false,
-		bool allowSynchronousContinuations = false)
-		=> new BatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, singleReader, allowSynchronousContinuations);
+		bool allowSynchronousContinuations = false,
+		Func<int, List<T>>? batchFactory = null)
+		=> new BatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, singleReader, allowSynchronousContinuations, batchFactory);
 
-	/// <inheritdoc cref="Batch{T}(ChannelReader{T}, int, bool, bool)" />
+	/// <inheritdoc cref="Batch{T}(ChannelReader{T}, int, bool, bool, Func{int, List{T}}?)" />
 	public static BatchingChannelReader<T, Queue<T>> BatchToQueues<T>(
 		this ChannelReader<T> source,
 		int batchSize,
 		bool singleReader = false,
-		bool allowSynchronousContinuations = false)
-		=> new QueueBatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, singleReader, allowSynchronousContinuations);
+		bool allowSynchronousContinuations = false,
+		Func<int, Queue<T>>? batchFactory = null)
+		=> new QueueBatchingChannelReader<T>(source ?? throw new ArgumentNullException(nameof(source)), batchSize, singleReader, allowSynchronousContinuations, batchFactory);
 
 	/// <remarks>
 	/// <list type="bullet">
+	/// <item>Use when batching is needed and memory constraints are critical.</item>
 	/// <item>The <see cref="Memory{T}"/> returned will always be less than or equal to the batch size.</item>
 	/// <item>It is important to manage disposing of the resultant <see cref="IMemoryOwner{T}"/> and not access them after disposal.</item>
+	/// <item>With proper disposal, the larger the batch size, the less memory will be allocated compared to the other batch methods and garbage collection may be eliminated since the memory is pooled.</item>
 	/// </list>
-	/// See <see cref="MemoryPool{T}"/> for more information. It may be more benefitial to use this for larger batch sizes.
+	/// See <see cref="MemoryPool{T}"/> for more information.
 	/// </remarks>
-	/// <inheritdoc cref="Batch{T}(ChannelReader{T}, int, bool, bool)" />
+	/// <inheritdoc cref="Batch{T}(ChannelReader{T}, int, bool, bool, Func{int, List{T}}?)" />
 	public static BatchingChannelReader<T, IMemoryOwner<T>> BatchAsMemory<T>(
 		this ChannelReader<T> source,
 		int batchSize,

--- a/Open.ChannelExtensions/Extensions.Join.cs
+++ b/Open.ChannelExtensions/Extensions.Join.cs
@@ -1,8 +1,13 @@
-﻿namespace Open.ChannelExtensions;
+﻿using System.Buffers;
+
+namespace Open.ChannelExtensions;
 
 public static partial class Extensions
 {
-	sealed class JoiningChannelReader<TList, T>(ChannelReader<TList> source, bool singleReader)
+	sealed class JoiningChannelReader<TList, T>(
+		ChannelReader<TList> source,
+		bool singleReader,
+		Action<TList>? recycler = null)
 		: BufferingChannelReader<TList, T>(source, singleReader)
 		where TList : IEnumerable<T>
 	{
@@ -12,9 +17,10 @@ public static partial class Extensions
 			if (source?.Completion.IsCompleted != false || Buffer is null)
 				return false;
 
+			TList? batch;
 			lock (Buffer)
 			{
-				if (!source.TryRead(out TList? batch))
+				if (!source.TryRead(out batch))
 					return false;
 
 				foreach (T? i in batch)
@@ -22,60 +28,150 @@ public static partial class Extensions
 					// Assume this will always be true for our internal unbound channel.
 					Buffer.Writer.TryWrite(i);
 				}
-
-				return true;
 			}
+
+			recycler?.Invoke(batch);
+
+			return true;
 		}
 	}
 
-	/// <summary>
-	/// Joins collections of the same type into a single channel reader in the order provided.
-	/// </summary>
-	/// <typeparam name="T">The result type.</typeparam>
-	/// <param name="source">The source reader.</param>
-	/// <param name="singleReader">True will cause the resultant reader to optimize for the assumption that no concurrent read operations will occur.</param>
-	/// <returns>A channel reader containing the joined results.</returns>
-	public static ChannelReader<T> Join<T>(this ChannelReader<IEnumerable<T>> source, bool singleReader = false)
-		=> new JoiningChannelReader<IEnumerable<T>, T>(source, singleReader);
+	sealed class QueueJoiningChannelReader<T>(
+		ChannelReader<Queue<T>> source,
+		bool singleReader, Action<Queue<T>>? recycler)
+		: BufferingChannelReader<Queue<T>, T>(source, singleReader)
+	{
+		protected override bool TryPipeItems(bool _)
+		{
+			ChannelReader<Queue<T>>? source = Source;
+			if (source?.Completion.IsCompleted != false || Buffer is null)
+				return false;
+
+			Queue<T>? batch;
+			lock (Buffer)
+			{
+				if (!source.TryRead(out batch))
+					return false;
+
+				while (batch.TryDequeue(out T? i))
+				{
+					// Assume this will always be true for our internal unbound channel.
+					Buffer.Writer.TryWrite(i);
+				}
+			}
+
+			recycler?.Invoke(batch);
+
+			return true;
+		}
+	}
+
+	sealed class MemoryJoiningChannelReader<T>(
+		ChannelReader<IMemoryOwner<T>> source,
+		bool singleReader)
+		: BufferingChannelReader<IMemoryOwner<T>, T>(source, singleReader)
+	{
+		protected override bool TryPipeItems(bool _)
+		{
+			ChannelReader<IMemoryOwner<T>>? source = Source;
+			if (source?.Completion.IsCompleted != false || Buffer is null)
+				return false;
+
+			IMemoryOwner<T>? batch = null;
+			try
+			{
+				lock (Buffer)
+				{
+					if (!source.TryRead(out batch))
+						return false;
+					var mem = batch.Memory;
+					int len = mem.Length;
+					var span = mem.Span;
+					for (var i = 0; i < len; i++)
+					{
+						// Assume this will always be true for our internal unbound channel.
+						Buffer.Writer.TryWrite(span[i]);
+					}
+				}
+			}
+			finally
+			{
+				batch?.Dispose();
+			}
+
+			return true;
+		}
+	}
+
+#if NETSTANDARD2_0
+	internal static bool TryDequeue<T>(this Queue<T> queue, out T item)
+	{
+		if (queue.Count == 0)
+		{
+			item = default!;
+			return false;
+		}
+
+		item = queue.Dequeue();
+		return true;
+	}
+#endif
 
 	/// <summary>
 	/// Joins collections of the same type into a single channel reader in the order provided.
 	/// </summary>
 	/// <typeparam name="T">The result type.</typeparam>
+	/// <typeparam name="TList">The collection type.</typeparam>
 	/// <param name="source">The source reader.</param>
 	/// <param name="singleReader">True will cause the resultant reader to optimize for the assumption that no concurrent read operations will occur.</param>
+	/// <param name="recycler">An optional delegate for reusing the already consumed batches.</param>
 	/// <returns>A channel reader containing the joined results.</returns>
-	public static ChannelReader<T> Join<T>(this ChannelReader<ICollection<T>> source, bool singleReader = false)
-		=> new JoiningChannelReader<ICollection<T>, T>(source, singleReader);
+	public static ChannelReader<T> Join<T, TList>(
+		this ChannelReader<TList> source,
+		bool singleReader = false,
+		Action<TList>? recycler = null)
+		where TList : IEnumerable<T>
+		=> new JoiningChannelReader<TList, T>(source, singleReader, recycler);
 
-	/// <summary>
-	/// Joins collections of the same type into a single channel reader in the order provided.
-	/// </summary>
-	/// <typeparam name="T">The result type.</typeparam>
-	/// <param name="source">The source reader.</param>
-	/// <param name="singleReader">True will cause the resultant reader to optimize for the assumption that no concurrent read operations will occur.</param>
-	/// <returns>A channel reader containing the joined results.</returns>
-	public static ChannelReader<T> Join<T>(this ChannelReader<IList<T>> source, bool singleReader = false)
-		=> new JoiningChannelReader<IList<T>, T>(source, singleReader);
+	/// <inheritdoc cref="Join{T, TList}(ChannelReader{TList}, bool, Action{TList}?)"/>
+	public static ChannelReader<T> Join<T>(
+		this ChannelReader<ICollection<T>> source,
+		bool singleReader = false,
+		Action<ICollection<T>>? recycler = null)
+		=> new JoiningChannelReader<ICollection<T>, T>(source, singleReader, recycler);
 
-	/// <summary>
-	/// Joins collections of the same type into a single channel reader in the order provided.
-	/// </summary>
-	/// <typeparam name="T">The result type.</typeparam>
-	/// <param name="source">The source reader.</param>
-	/// <param name="singleReader">True will cause the resultant reader to optimize for the assumption that no concurrent read operations will occur.</param>
-	/// <returns>A channel reader containing the joined results.</returns>
-	public static ChannelReader<T> Join<T>(this ChannelReader<List<T>> source, bool singleReader = false)
-		=> new JoiningChannelReader<List<T>, T>(source, singleReader);
+	/// <inheritdoc cref="Join{T, TList}(ChannelReader{TList}, bool, Action{TList}?)"/>
+	public static ChannelReader<T> Join<T>(
+		this ChannelReader<IList<T>> source,
+		bool singleReader = false,
+		Action<IList<T>>? recycler = null)
+		=> new JoiningChannelReader<IList<T>, T>(source, singleReader, recycler);
 
-	/// <summary>
-	/// Joins collections of the same type into a single channel reader in the order provided.
-	/// </summary>
-	/// <typeparam name="T">The result type.</typeparam>
-	/// <param name="source">The source reader.</param>
-	/// <param name="singleReader">True will cause the resultant reader to optimize for the assumption that no concurrent read operations will occur.</param>
-	/// <returns>A channel reader containing the joined results.</returns>
-	public static ChannelReader<T> Join<T>(this ChannelReader<T[]> source, bool singleReader = false)
+	/// <inheritdoc cref="Join{T, TList}(ChannelReader{TList}, bool, Action{TList}?)"/>
+	public static ChannelReader<T> Join<T>(
+		this ChannelReader<List<T>> source,
+		bool singleReader = false,
+		Action<List<T>>? recycler = null)
+		=> new JoiningChannelReader<List<T>, T>(source, singleReader, recycler);
+
+	/// <inheritdoc cref="Join{T, TList}(ChannelReader{TList}, bool, Action{TList}?)"/>
+	public static ChannelReader<T> Join<T>(
+		this ChannelReader<Queue<T>> source,
+		bool singleReader = false,
+		Action<Queue<T>>? recycler = null)
+		=> new QueueJoiningChannelReader<T>(source, singleReader, recycler);
+
+	/// <remarks>Automatically disposes of the <see cref="IMemoryOwner{T}"/>.</remarks>
+	/// <inheritdoc cref="Join{T, TList}(ChannelReader{TList}, bool, Action{TList}?)"/>
+	public static ChannelReader<T> Join<T>(
+		this ChannelReader<IMemoryOwner<T>> source,
+		bool singleReader = false)
+		=> new MemoryJoiningChannelReader<T>(source, singleReader);
+
+	/// <inheritdoc cref="Join{T, TList}(ChannelReader{TList}, bool, Action{TList}?)"/>
+	public static ChannelReader<T> Join<T>(
+		this ChannelReader<T[]> source,
+		bool singleReader = false)
 		=> new JoiningChannelReader<T[], T>(source, singleReader);
 
 	/// <summary>

--- a/Open.ChannelExtensions/Open.ChannelExtensions.csproj
+++ b/Open.ChannelExtensions/Open.ChannelExtensions.csproj
@@ -22,7 +22,7 @@
 		<RepositoryType>git</RepositoryType>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<Version>8.5.0</Version>
+		<Version>8.6.0</Version>
 		<PackageReleaseNotes>Added .Merge, .PipeAsync, and .PropagateCompletion extensions.</PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Implemented new "poolable" batch and join extensions.

![image](https://github.com/user-attachments/assets/7f43ff0e-c791-4e45-a3ef-6a62a81cce34)
