### PR TITLE
Lower .NET Standard 2.0/2.1 dependency versions to 6.0.0

### DIFF
--- a/Open.ChannelExtensions/Open.ChannelExtensions.csproj
+++ b/Open.ChannelExtensions/Open.ChannelExtensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0; netstandard2.1; net6.0; net8.0; net9.0;</TargetFrameworks>
@@ -22,8 +22,8 @@
 		<RepositoryType>git</RepositoryType>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<Version>9.1.3</Version>
-		<PackageReleaseNotes></PackageReleaseNotes>
+		<Version>9.2.0</Version>
+		<PackageReleaseNotes>Lowered .NET Standard 2.0/2.1 dependency versions to 6.0.0 to reduce minimum requirements for consumers.</PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
@@ -50,12 +50,12 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="System.Threading.Channels" Version="9.*" />
-		<PackageReference Include="System.Collections.Immutable" Version="9.*" />
+		<PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+		<PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.*" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 	</ItemGroup>
 
 	<!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->


### PR DESCRIPTION
## Summary

Lowers the minimum dependency versions for .NET Standard 2.0 and 2.1 targets from `9.*` to `6.0.0` for:
- `System.Threading.Channels`
- `System.Collections.Immutable`
- `Microsoft.Bcl.AsyncInterfaces`

## Motivation

The `9.*` floating versions forced consumers to pull in >= 9.x.x packages for their .NET Standard 2.0 builds, which is higher than what the .NET 8 target requires (runtime-included). This was an unusual situation where the 'lower' target had higher dependency requirements than the 'higher' runtime target.

Since the core APIs used by this library have been stable since 6.0.0, lowering the floor gives consumers maximum flexibility without any functionality loss.

## Changes
- Bumped version to **9.2.0**
- Changed `Version="9.*"` to `Version="6.0.0"` for netstandard2.0/2.1 conditional dependencies
- Added release notes

Closes #54